### PR TITLE
Correcting a typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ cp settings.js.sample settings.js
 Run the app
 
 ```
-nodejs app.js
+node app.js
 ```
 
 Party time: [http://localhost:5000](http://localhost:5000)


### PR DESCRIPTION
```
nodejs app.js
```

doesn't work for me, suggest;

```
node app.js
```
