### PR TITLE
Add heroku support out of the box

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,3 +56,40 @@ node app.js
 ```
 
 Party time: [http://localhost:5000](http://localhost:5000)
+
+## Deploying to Heroku
+
+Remove settings.js from .gitignore and uncomment the line `// db_url: process.env.DATABASE_URL`. Be sure to set the DATABASE_URL config variable on heroku to your mongo url. To get your mongo URL, add a mongolab add-on, find its database url config variable, and set the DATABASE_URL to that url. For instance, to do this with the free tier of mongolab on a heroku app called heroku-app-name:
+
+```
+heroku addons:add mongolab -a heroku-app-name
+heroku config:set DATABASE_URL=`heroku config:get MONGOLAB_URI -a heroku-app-name` -a heroku-app-name
+```
+
+Additionally, you should set the following config variables from heroku config variables by changing their values to `config_var_name: process.env.CONFIG_VAR_NAME` and running `heroku config:set CONFIG_VAR_NAME=config_var_value -a heroku-app-name`:
+
+```
+cookie_secret
+password_salt
+s3.accessKeyId
+s3.secretAccessKey
+s3.region
+s3.bucket
+```
+
+Note that you must use s3 (or hack in a different solution) to allow file uploads with lets-chat on heroku, as the filesystem is not persisted across heroku deploys.
+
+Finally, be sure to enable heroku's websockets support, otherwise socket.io will fall back to XHR polling and run super slowly.
+
+```
+heroku labs:enable websockets -a heroku-app-name
+```
+
+Now you can push your app to heroku!
+
+```
+git remote add heroku git@heroku.com:heroku-app-name.git
+git push heroku master
+```
+
+You must compile all of your assets and commit them before deploying (TODO: heroku asset pipeline?).

--- a/app/server.js
+++ b/app/server.js
@@ -44,7 +44,7 @@ var Server = function(config) {
     self.config = config;
 
     // Mongo URL
-    self.mongoURL = 'mongodb://'
+    self.mongoURL = self.config.db_url || 'mongodb://'
         + self.config.db_user
         + ':' + self.config.db_password
         + '@' + self.config.db_host 

--- a/settings.js.sample
+++ b/settings.js.sample
@@ -2,7 +2,7 @@ var config = {
 
     // Server
     host: '', // Not required
-    port: 5000,
+    port: process.env.PORT || 5000,
 
     // Registration
     disable_registration: false,
@@ -22,6 +22,9 @@ var config = {
     db_name: 'letschatbro',
     db_user: '',
     db_password: '',
+
+    // Overrides the above settings (helpful for heroku)
+    // db_url: process.env.DATABASE_URL,
 
     // Security
     // Please change these!


### PR DESCRIPTION
Adds obvious support for PORT and DATABASE_URL config vars to conform to heroku conventions, and add instructions in readme.md. Fixes #65. 
