### PR TITLE
Add Fig support (for Docker)

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,16 @@
+# Let's Chat: Fig Integration
+# http://fig.sh
+#
+# Usage: fig up
+
+# Let's Chat application
+app:
+  build: .
+  links:
+   - db:db
+  ports:
+   - "5000:5000"
+
+# Mongo Database
+db:
+  image: mongo


### PR DESCRIPTION
[Fig](http://fig.sh) is a wrapper for Docker, which allows easy maintenance of multiple Docker containers. It will become what was [announced as Docker Compose](http://blog.docker.com/2015/01/dockercon-eu-introducing-docker-compose/).

This pull request adds a `fig.yml` file which leverages [Let's Chat's `Dockerfile`](https://github.com/sdelements/lets-chat/blob/master/Dockerfile) (as [documented in the wiki](https://github.com/sdelements/lets-chat/wiki/Docker)) and makes running Let's Chat as easy as:
``` bash
fig up
```

Once merged, a Fig section should be [added to the Docker section of the wiki](https://github.com/sdelements/lets-chat/wiki/Docker) so that people have the option to either use Docker directly, or simply use Fig.