### PR TITLE
Use mounted volume rather than checking out from GitHub's master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER SD Elements
 RUN apt-get update
 RUN apt-get install -y nodejs nodejs-legacy npm git libkrb5-dev
 
-# TODO: pull branch from environment variable?
-RUN git clone -b master https://github.com/sdelements/lets-chat.git
+# Ensure to mount the Let's Chat repository as "/lets-chat".
+VOLUME "/lets-chat"
 
-WORKDIR lets-chat
+WORKDIR /lets-chat
 RUN npm install
 
 ENV LCB_DATABASE_URI mongodb://db/letschat


### PR DESCRIPTION
Having Docker check out from `master` means if you make any local changes, you can't test them locally in Docker. Using a [mounted `VOLUME`](https://docs.docker.com/reference/builder/#volume) means you can do local development through Docker.

The [Docker wiki instructions](https://github.com/sdelements/lets-chat/wiki/Docker) will have to be updated to include [`--volume`/`-v`](https://docs.docker.com/reference/commandline/cli/):
```
docker run -p 5000:5000 -v .:/lets-chat --link db:db lets-chat
```