### PR TITLE
Use official node-container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,5 @@
-FROM ubuntu:latest
+FROM node:0.10-onbuild
 MAINTAINER SD Elements
 
-RUN apt-get update
-RUN apt-get install -y nodejs nodejs-legacy npm git
-
-RUN git clone -b master https://github.com/sdelements/lets-chat.git
-
-WORKDIR /lets-chat
-RUN npm install
-
 ENV LCB_DATABASE_URI mongodb://db/letschat
-
 EXPOSE 5000
-
-CMD ["npm", "start"]


### PR DESCRIPTION
This change makes use of the offical node-onbuild container, no need make a custom node/npm installation.