### PR TITLE
Add instructions to start Let's Chat

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -102,11 +102,10 @@ npm install
 <pre>
 cp settings.yml.sample settings.yml
 </pre>
-                            <p>Run Let's Chat:
+                            <p>Run Let's Chat:</p>
 <pre>
 npm start
 </pre>
-                            </p>
                             <p>Party time at <a href="http://localhost:5000/" target="_blank">http://localhost:5000/</a>!</p>
                             <h4>Got Heroku?</h4>
                             <p>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -102,6 +102,11 @@ npm install
 <pre>
 cp settings.yml.sample settings.yml
 </pre>
+                            <p>Run Let's Chat:
+<pre>
+npm start
+</pre>
+                            </p>
                             <p>Party time at <a href="http://localhost:5000/" target="_blank">http://localhost:5000/</a>!</p>
                             <h4>Got Heroku?</h4>
                             <p>


### PR DESCRIPTION
Hey, I don't know if I missed something, but the instructions didn't seem to tell how to run the app. I figured it was `npm start` looking at `package.json`, but it's not on the home page. So I hope this pullrequest improves things! Aweomse project :)