### PR TITLE
Add/disable/enable local users via command-line

### DIFF
--- a/app/core/account.js
+++ b/app/core/account.js
@@ -111,4 +111,15 @@ AccountManager.prototype.revokeToken = function(id, cb) {
     User.update({_id: id}, {$unset: {token: 1}}, cb);
 };
 
+AccountManager.prototype.deactivate = function(email, cb) {
+    var User = mongoose.model('User');
+
+    User.update({email: email}, {active:false}, cb);
+}
+
+AccountManager.prototype.activate = function(email, cb) {
+    var User = mongoose.model('User');
+
+    User.update({email: email}, {active:true}, cb);
+}
 module.exports = AccountManager;

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -83,6 +83,10 @@ var UserSchema = new mongoose.Schema({
         type: Date,
         default: Date.now
     },
+    active: {
+        type: Boolean,
+        default: true
+    },
     status: {
         type: String,
         trim: true
@@ -229,6 +233,11 @@ UserSchema.statics.authenticate = function(identifier, password, cb) {
         // Is this a local user?
         if (user.provider !== 'local') {
             return cb(null, null, 0);
+        }
+
+        // (Is the user active?
+        if (!user.active) {
+            return cb(null, null, 1);
         }
 
         // Is password okay?

--- a/manage.js
+++ b/manage.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+var mongoose = require('mongoose'),
+    migroose = require('./migroose'),
+    all = require('require-tree'),
+    models = all('./app/models'),
+    MongoStore = require('connect-mongo'),
+    settings = require('./app/config'),
+    core = require('./app/core/index');
+
+var program = require('commander');
+
+//
+// Mongo
+//
+
+mongoose.connection.on('error', function (err) {
+    throw new Error(err);
+});
+
+mongoose.connection.on('disconnected', function() {
+    throw new Error('Could not connect to database');
+});
+
+mongoose.connect(settings.database.uri, function(err) {
+    if (err) {
+        throw err;
+    }
+
+
+    program
+      .command('disable_user [email]')
+      .description('Disable user in Lets Chat')
+      .action(function(email, options){
+        core.account.deactivate(email, function(error){
+            if (error){
+                console.log(error);
+            }
+            else {
+                console.log('Disabled user with email %s', email);
+            }
+            process.exit(0);
+        });
+      });
+
+    program
+      .command('enable_user [email]')
+      .description('Enable user in Lets Chat')
+      .action(function(email, options){
+        core.account.activate(email, function(error){
+            if (error){
+                console.log(error);
+            }
+            else {
+                console.log('Activated user with email %s', email);
+            }
+            process.exit(0);
+        });
+      });
+
+    program
+      .command('add_user [provider] [email] [fname] [lname] [uname] [pwd]')
+      .description('Add user to Lets Chat')
+      .action(function(provider, email, fname, lname, uname, pwd){
+        var attrs = {
+            email: email,
+            username: uname,
+            firstName: fname,
+            lastName: lname,
+            displayName: fname + ' ' + lname,
+            password: pwd,
+        };
+        core.account.create(provider, attrs, function(error){
+            if (error){
+                console.log(error);
+            }
+            else {
+                console.log('Added user with email %s', email);
+            }
+            process.exit(0);
+        });
+      });
+ 
+    program.parse(process.argv);
+});

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "bcryptjs": "~2.1.0",
     "body-parser": "^1.11.0",
     "colors": "~1.0.3",
+    "commander": "2.6.0",
     "compression": "^1.4.0",
     "connect-assets": "^4.6.0",
     "connect-mongo": "^0.7.0",


### PR DESCRIPTION
A command-line tool for adding, enabling and disabling Lets Chat users.

NOTE: This actually works but the code is poorly written/laid out. Most may get get thrown out with the bath water. I'll probably iterate over this and then squash the commits later. Do not use for anything.

**Create user account:**

`vagrant@precise32:~/lets-chat$ ./manage.js add_user local bob@aol.com first_name last_name username userpass`

**Disable a user account:**

`vagrant@precise32:~/lets-chat$ ./manage.js disable_user bob@aol.com`

**Enable a user account:**

`vagrant@precise32:~/lets-chat$ ./manage.js enable_user bob@aol.com`
