### PR TITLE
Proof of concept support for slack incoming webhook

### DIFF
--- a/app/controllers/plugin-api-slack.js
+++ b/app/controllers/plugin-api-slack.js
@@ -1,0 +1,50 @@
+//
+// Slack API Controller
+//
+
+'use strict';
+
+module.exports = function() {
+
+    var app = this.app,
+        core = this.core,
+        middlewares = this.middlewares;
+
+    //
+    // Routes
+    //
+    app.route('/services/hooks/incoming-webhook')
+        .all(middlewares.requireLogin)
+        .post(function(req, res) {
+
+            // Support the payload form variable
+            var payload = req.body.payload;
+            if (payload) {
+                payload = JSON.parse(payload);
+                req.params['channel'] = payload.channel;
+                req.params['text'] = payload.text;
+            }
+
+            var options = {
+                    owner: req.user._id,
+                    room: req.param('channel'),
+                    text: req.param('text')
+                };
+
+            core.messages.create(options, function(err, message) {
+                if (err) {
+                    res.status(400).json({
+                        ok: false,
+                        error: err
+                    });
+                }
+                else {
+                    res.status(201).json({
+                        ok: true,
+                        channel: options.room
+                    });
+                }
+            });
+
+        });
+};


### PR DESCRIPTION
This is an attempt to address #278. My expectation is that this will be move to a plugin and enabled via settings.

Key points:
 - Only supports `text` and `channel`
 - Room ID is the `channel`, room slug is not supported
 - Does not support default channel, i.e. `channel` must be supplied
 - Does not support impersonation using `username`
 - Does not support attachments, message formatting, icon

Example:

```
POST http://localhost:5000/services/hooks/incoming-webhook
payload={"text":"Some text", "channel": "54e7ff8689fdc6d20c8b2d1b"}
```

Response:

```
{
ok: true
channel: "54e7ff8689fdc6d20c8b2d1b"
}
```