### PR TITLE
Include headers in authentication methods 

### DIFF
--- a/app/auth/index.js
+++ b/app/auth/index.js
@@ -143,7 +143,7 @@ function wrapAuthCallback(username, cb) {
     };
 }
 
-function authenticate(username, password, cb) {
+function authenticate(username, password, headers, cb) {
     username = username.toLowerCase();
 
     checkIfAccountLocked(username, function(locked) {
@@ -163,7 +163,8 @@ function authenticate(username, password, cb) {
             body: {
                 username: username,
                 password: password
-            }
+            },
+            headers: headers
         };
 
         var series = enabledProviders.map(function(provider) {

--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -129,7 +129,7 @@ module.exports = function() {
                         form.confirmPassword
                 };
 
-            auth.authenticate(req.user.uid || req.user.username,
+            auth.authenticate(req.user.uid || req.user.username, req.headers,
                               data.currentPassword, function(err, user) {
                 if (err) {
                     return res.status(400).json({
@@ -263,7 +263,7 @@ module.exports = function() {
             });
         },
         login: function(req, res) {
-            auth.authenticate(req.body.username, req.body.password,
+            auth.authenticate(req.body.username, req.body.password, req.headers,
                                                  function(err, user, info) {
                 if (err) {
                     return res.status(400).json({


### PR DESCRIPTION
used for [lets-chat-reverseproxy](https://github.com/Schniz/lets-chat-reverseproxy)

there are some organizations that use Kerberos or some authentication via SSO headers (`REMOTE_USER`, `X-Remote-User` and so on).
the `passport-reverseproxy` came to the rescue, but the `req` object in `app/auth/index.js` only sends the `user` and `password`. for `reverseproxy` it should also send the `headers` so we could authenticate the user.

plus, if we will make it happen, users won't have to actively sign in in organizations with SSO headers. auto login for the win.
but the auto login is not implemented here yet.
maybe the app should let the plugins to authenticate automatically the users?