### PR TITLE
Filter requests based on Origin header to deal with Cross origin request forgery

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,6 +97,21 @@ app.use(helmet.contentSecurityPolicy({
     imgSrc: ['*']
 }));
 
+// Disable cross-origin request sharing
+if(settings.security.serverAuthority){
+    app.use(function(req, res, next){
+        if(req.headers.origin && req.headers.origin !== settings.security.serverAuthority){
+            res.status(403).send({
+                status: 'error',
+                message: 'Requests not allowed from this origin'
+            });
+        }
+        else {
+            next();
+        }
+    });
+}
+
 var bundles = {};
 app.use(require('connect-assets')({
     paths: [

--- a/app.js
+++ b/app.js
@@ -98,9 +98,9 @@ app.use(helmet.contentSecurityPolicy({
 }));
 
 // Disable cross-origin request sharing
-if(settings.security.serverAuthority){
+if(settings.security.allowOrigin){
     app.use(function(req, res, next){
-        res.header('Access-Control-Allow-Origin', settings.security.serverAuthority);
+        res.header('Access-Control-Allow-Origin', settings.security.allowOrigin);
         res.header('Access-Control-Allow-Credentials', true);
         res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
         res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
@@ -114,7 +114,7 @@ if(settings.security.serverAuthority){
         } // Continue with the process
     });
     app.use(function(req, res, next){
-        if(req.headers.origin && req.headers.origin !== settings.security.serverAuthority){
+        if(req.headers.origin && req.headers.origin !== settings.security.allowOrigin){
             res.status(403).send({
                 status: 'error',
                 message: 'Requests not allowed from this origin'

--- a/app.js
+++ b/app.js
@@ -100,6 +100,20 @@ app.use(helmet.contentSecurityPolicy({
 // Disable cross-origin request sharing
 if(settings.security.serverAuthority){
     app.use(function(req, res, next){
+        res.header('Access-Control-Allow-Origin', settings.security.serverAuthority);
+        res.header('Access-Control-Allow-Credentials', true);
+        res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
+        res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+        res.header("Access-Control-Max-Age", 86400);
+
+        if (req.method=='OPTIONS'){
+            res.send(200);
+        }
+        else{
+            next();
+        } // Continue with the process
+    });
+    app.use(function(req, res, next){
         if(req.headers.origin && req.headers.origin !== settings.security.serverAuthority){
             res.status(403).send({
                 status: 'error',

--- a/defaults.yml
+++ b/defaults.yml
@@ -58,3 +58,6 @@ auth:
     salt: secretsauce # Required when upgrading from version < 0.3
 
 noRobots: true # Serve robots.txt with disallow
+
+security:
+  allowOrigin: ''


### PR DESCRIPTION
Best practices is to check the `Origin` header: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29_Prevention_Cheat_Sheet#Checking_The_Origin_Header

This PR implements this best practice, if such a header exists, and sends back a `Forbidden` response if its value does not match a white-listed value. The whitelisted value is set in a new setting, `security.serverAuthority`. i.e.

```
security:
    serverAuthority: 'https://good.server.com:3345/'
```

Edit: Removed note