### PR TITLE
Added link to azure storage plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A self-hosted chat app for small teams built by [Security Compass][seccom].
 * Mentions (hey @you)
 * Image embeds
 * Code pasting
-* File uploads (Local / [Amazon S3][s3])
+* File uploads (Local / [Amazon S3][s3] / [Azure][azure])
 * Transcripts / chat history
 * XMPP Multi-user chat (MUC)
 * Local / [Kerberos][kerberos] / [LDAP][ldap] authentication
@@ -81,3 +81,4 @@ Released under [the MIT license][license].
 [s3]: https://github.com/sdelements/lets-chat-s3
 [seccom]: http://securitycompass.com/
 [hubot]: https://github.com/sdelements/hubot-lets-chat
+[azure]: https://github.com/maximilian-krauss/lets-chat-azure


### PR DESCRIPTION
I added a link to my Azure storage plugin to your README file.

I wasn't sure where the best place would be to place that link, so I added it to the list of available file uploads. Alternatively we could create an 3rd party section for all plugins which were not developed by you or something like that ...
