### PR TITLE
Flag Post to room didn't work

### DIFF
--- a/app/controllers/files.js
+++ b/app/controllers/files.js
@@ -96,7 +96,7 @@ module.exports = function() {
                     owner: req.user._id,
                     room: req.param('room'),
                     file: req.files.file[0],
-                    post: req.param('post') && true
+                    post: (req.param('post') === 'true') && true
                 };
 
             core.files.create(options, function(err, file) {


### PR DESCRIPTION
New uploads were always posted in the room, regardless of the flag "Post to room" was set or not.

The result of  ``` req.param('post') ``` is a string which caused the comparsion to return always true.