### PR TITLE
Add process title

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,8 @@
 
 'use strict';
 
+process.title = "letschat";
+
 var _ = require('lodash'),
     fs = require('fs'),
     colors = require('colors'),


### PR DESCRIPTION
I'm running lets-chat by a custom init script and it's a bit of a problem that the process is called `app` for purpose of `ps`, `pidof` and relatives. This patch changes the process title to a unique `letschat`. I opted to not include a space or dash in the name for compatibility.