### PR TITLE
Fixed some issues with transcripts/room history when a user is deleted

### DIFF
--- a/media/js/views/room.js
+++ b/media/js/views/room.js
@@ -274,7 +274,7 @@
             var posted = moment(message.posted);
 
             // Fragment or new message?
-            message.fragment = this.lastMessageOwner === message.owner && message.owner.id &&
+            message.fragment = (this.lastMessageOwner === (message.owner ? message.owner.id : null)) &&
                             posted.diff(this.lastMessagePosted, 'minutes') < 5;
 
             // Create 'Unknown' owner if owner is null
@@ -282,7 +282,7 @@
                 message.owner = {
                     displayName: 'Unknown',
                     username: '_unknown'
-                }
+                };
             }
 
             // Mine? Mine? Mine? Mine?

--- a/media/js/views/room.js
+++ b/media/js/views/room.js
@@ -274,8 +274,16 @@
             var posted = moment(message.posted);
 
             // Fragment or new message?
-            message.fragment = this.lastMessageOwner === message.owner.id &&
+            message.fragment = this.lastMessageOwner === message.owner && message.owner.id &&
                             posted.diff(this.lastMessagePosted, 'minutes') < 5;
+
+            // Create 'Unknown' owner if owner is null
+            if (message.owner === null) {
+                message.owner = {
+                    displayName: 'Unknown',
+                    username: '_unknown'
+                }
+            }
 
             // Mine? Mine? Mine? Mine?
             message.own = this.client.user.id === message.owner.id;
@@ -292,7 +300,7 @@
                 $text.html(text);
                 $html.find('time').updateTimeStamp();
                 that.$messages.append($html);
-                that.lastMessageOwner = message.owner.id;
+                that.lastMessageOwner = message.owner && message.owner.id ? message.owner.id : null;
                 that.lastMessagePosted = posted;
                 that.scrollMessages();
 

--- a/media/js/views/transcript.js
+++ b/media/js/views/transcript.js
@@ -102,7 +102,7 @@
             var posted = moment(message.posted);
 
             // Fragment or new message?
-            message.fragment = this.lastMessageOwner === message.owner.id &&
+            message.fragment = this.lastMessageOwner === message.owner && message.owner.id &&
                             posted.diff(this.lastMessagePosted, 'minutes') < 5;
 
             // Templatin' time

--- a/media/js/views/transcript.js
+++ b/media/js/views/transcript.js
@@ -113,7 +113,7 @@
 
             this.formatTimestamp($html.find('time'));
             this.$messages.append($html);
-            this.lastMessageOwner = message.owner.id;
+            this.lastMessageOwner = message.owner && message.owner.id ? message.owner.id : 'Unknown';
             this.lastMessagePosted = posted;
         },
         formatMessage: function(text) {

--- a/media/js/views/transcript.js
+++ b/media/js/views/transcript.js
@@ -102,7 +102,7 @@
             var posted = moment(message.posted);
 
             // Fragment or new message?
-            message.fragment = this.lastMessageOwner === message.owner && message.owner.id &&
+            message.fragment = (this.lastMessageOwner === (message.owner ? message.owner.id : null)) &&
                             posted.diff(this.lastMessagePosted, 'minutes') < 5;
 
             // Create 'Unknown' owner if owner is null
@@ -110,7 +110,7 @@
                 message.owner = {
                     displayName: 'Unknown',
                     username: '_unknown'
-                }
+                };
             }
 
             // Templatin' time

--- a/media/js/views/transcript.js
+++ b/media/js/views/transcript.js
@@ -105,6 +105,14 @@
             message.fragment = this.lastMessageOwner === message.owner && message.owner.id &&
                             posted.diff(this.lastMessagePosted, 'minutes') < 5;
 
+            // Create 'Unknown' owner if owner is null
+            if (message.owner === null) {
+                message.owner = {
+                    displayName: 'Unknown',
+                    username: '_unknown'
+                }
+            }
+
             // Templatin' time
             var $html = $(this.messageTemplate(message).trim());
             var $text = $html.find('.lcb-message-text');
@@ -113,7 +121,7 @@
 
             this.formatTimestamp($html.find('time'));
             this.$messages.append($html);
-            this.lastMessageOwner = message.owner && message.owner.id ? message.owner.id : 'Unknown';
+            this.lastMessageOwner = message.owner && message.owner.id ? message.owner.id : null;
             this.lastMessagePosted = posted;
         },
         formatMessage: function(text) {


### PR DESCRIPTION
If a user is deleted from the database, it can cause the app to throw several errors when trying to retrieve transcripts or room history. These errors prevent past messages from being shown correctly in many cases, greatly reducing the usefulness of the app.