### PR TITLE
Fixed some issues with transcripts/room history when a user is deleted

### DIFF
--- a/app/core/helpers.js
+++ b/app/core/helpers.js
@@ -1,4 +1,4 @@
-var User = require('user');
+var User = require('../models/user');
 
 module.exports = {
     sanitizeQuery: function(query, options) {

--- a/app/core/helpers.js
+++ b/app/core/helpers.js
@@ -16,5 +16,15 @@ module.exports = {
         }
 
         return query;
+    },
+    sanitizeOwner: function(messages) {
+        for (var i = 0; messages && (i < messages.length); i++) {
+            if (!messages.owner) {
+                messages.owner = {
+                    username: '_unknown',
+                    displayName: 'Unknown'
+                };
+            }
+        }
     }
 };

--- a/app/core/helpers.js
+++ b/app/core/helpers.js
@@ -1,3 +1,5 @@
+var User = require('user');
+
 module.exports = {
     sanitizeQuery: function(query, options) {
         if (options.defaults.take && !query.take) {
@@ -17,13 +19,14 @@ module.exports = {
 
         return query;
     },
+
     sanitizeOwner: function(messages) {
         for (var i = 0; messages && (i < messages.length); i++) {
-            if (!messages.owner) {
-                messages.owner = {
-                    username: '_unknown',
-                    displayName: 'Unknown'
-                };
+            if (!messages[i].owner) {
+                messages[i].owner = new User({
+                    displayName: 'Unknown',
+                    username: '_unknown'
+                });
             }
         }
     }

--- a/app/core/messages.js
+++ b/app/core/messages.js
@@ -116,7 +116,7 @@ MessageManager.prototype.list = function(options, cb) {
             }
 
             if (includesOwner) {
-                messages = helpers.sanitizeOwner(messages);
+                helpers.sanitizeOwner(messages);
             }
 
             cb(null, messages);

--- a/app/core/messages.js
+++ b/app/core/messages.js
@@ -67,6 +67,8 @@ MessageManager.prototype.list = function(options, cb) {
         room: options.room
     });
 
+    var includesOwner = false;
+
     if (options.since_id) {
         find.where('_id').gt(options.since_id);
     }
@@ -87,6 +89,7 @@ MessageManager.prototype.list = function(options, cb) {
         var includes = options.expand.replace(/\s/, '').split(',');
 
         if (_.includes(includes, 'owner')) {
+            includesOwner = true;
             find.populate('owner', 'id username displayName email avatar');
         }
 
@@ -111,6 +114,11 @@ MessageManager.prototype.list = function(options, cb) {
                 console.error(err);
                 return cb(err);
             }
+
+            if (includesOwner) {
+                messages = helpers.sanitizeOwner(messages);
+            }
+
             cb(null, messages);
         });
 };


### PR DESCRIPTION
If a user is deleted from the database, it can cause the app to throw several errors when trying to retrieve transcripts or room history. These errors prevent past messages from being shown correctly in many cases, greatly reducing the usefulness of the app.