### PR TITLE
Allow lets-chat to run from subfolder

### DIFF
--- a/app/controllers/extras.js
+++ b/app/controllers/extras.js
@@ -55,7 +55,7 @@ module.exports = function() {
                         fileName
                     );
 
-                    var imgDir = '/extras/emotes/' +
+                    var imgDir = 'extras/emotes/' +
                         fileName.replace('.yml', '') + '/';
 
                     var file = fs.readFileSync(fullpath, 'utf8');

--- a/media/js/client.js
+++ b/media/js/client.js
@@ -417,7 +417,8 @@
         //
         // Socket
         //
-        this.socket = io.connect(null, {
+        this.socket = io.connect({
+            path: '/' + _.compact(window.location.pathname.split('/').concat(['socket.io'])).join('/')
             reconnection: true,
             reconnectionDelay: 500,
             reconnectionDelayMax: 1000,


### PR DESCRIPTION
I am currently running lets-chat behind an NGINX reverse-proxy (example.org/lets-chat -> localhost:5000)
But by default socket.io try to established transport with / (aka: example.org instead of example.org/lets-chat)

Adding path parameter in ```io.connect``` allow reverse proxy setups to work