### PR TITLE
Moved username regex into defaults.yml to allow custom validation rules

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -72,7 +72,7 @@ var UserSchema = new mongoose.Schema({
         trim: true,
         lowercase: true,
         unique: true,
-        match: /^[^\.][a-z0-9_\.]+[^\.]$/i
+        match: new RegExp(settings.auth.usernameRegex)
     },
     displayName: {
         type: String,

--- a/defaults.yml
+++ b/defaults.yml
@@ -52,6 +52,7 @@ auth:
   throttling:
     enable: true
     threshold: 3
+  usernameRegex: ^[^\.][a-z0-9_\.]+[^\.]$
   providers: [local] # [local, kerberos, ldap] - You can specify the order
   local:
     enableRegistration: true


### PR DESCRIPTION
The username field still requires 3 or more characters, but it's configurable now :smile: 

Fixes #405 
