### PR TITLE
Allow unicode characters in URL

### DIFF
--- a/media/js/util/message.js
+++ b/media/js/util/message.js
@@ -136,8 +136,8 @@ if (typeof exports !== 'undefined') {
     var surrogatePairRegexp = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g,
         // Match everything outside of normal chars and " (quote character)
         nonAlphanumericRegexp = /([^\#-~| |!])/g,
-        imagePattern = /^\s*((https?|ftp):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;'"!()]*[-A-Z0-9+&@#\/%=~_|][.](jpe?g|png|gif))\s*$/i,
-        linkPattern = /((https?|ftp):\/\/[-A-Z0-9+&*@#\/%?=~_|!:,.;'"!()]*[-A-Z0-9+&@#\/%=~_|])/ig;
+        imagePattern = /^\s*((https?|ftp):\/\/[-A-Z0-9\u00a1-\uffff+&@#\/%?=~_|!:,.;'"!()]*[-A-Z0-9\u00a1-\uffff+&@#\/%=~_|][.](jpe?g|png|gif))\s*$/i,
+        linkPattern = /((https?|ftp):\/\/[-A-Z0-9\u00a1-\uffff+&*@#\/%?=~_|!:,.;'"!()]*[-A-Z0-9\u00a1-\uffff+&@#\/%=~_|])/ig;
 
     exports.format = function(text, data) {
         var pipeline = [


### PR DESCRIPTION
When formatting URLs to links in messages, unicode characters are now
accepted.

URLs like http://www.åäöü.fi/ work with the patch.