### PR TITLE
Add a "Try a demo" button

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -30,7 +30,8 @@
                 <div class="lc-header-featurette">
                     <img class="img-responsive" src="assets/img/devices.png" />
                 </div>
-                <a class="btn btn-lc btn-lg lc-lets-roll" href="#getting-started">Let's Roll</a>
+                <a class="btn btn-lc btn-lg lc-lets-roll" href="#getting-started">Install now</a>
+                <a class="btn btn-lc btn-md" href="https://demo.sandstorm.io/appdemo/qkgkaxfqhgsff8zgx2f4nf1a8xvmpte6wa19egmfkk06mzt7e8dh">Try a demo</a>
                 <div class="lc-header-source">
                     <a class="lc-header-source-link" href="https://github.com/sdelements/lets-chat" target="_blank"><i class="fa fa-github"></i> Source Code</a>
                 </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -13,7 +13,7 @@
         <script type="text/javascript" src="assets/js/vendor/jquery/jquery.js"></script>
         <script type="text/javascript">
         $(function() {
-            $('.lc-lets-roll').on('click', function(e) {
+            $('.lc-install-now').on('click', function(e) {
                 e.preventDefault();
                 $('html, body').animate({
                     scrollTop: $($(this).attr('href')).offset().top
@@ -30,7 +30,7 @@
                 <div class="lc-header-featurette">
                     <img class="img-responsive" src="assets/img/devices.png" />
                 </div>
-                <a class="btn btn-lc btn-lg lc-lets-roll" href="#getting-started">Install now</a>
+                <a class="btn btn-lc btn-lg lc-install-now" href="#getting-started">Install now</a>
                 <a class="btn btn-lc btn-md" href="https://demo.sandstorm.io/appdemo/qkgkaxfqhgsff8zgx2f4nf1a8xvmpte6wa19egmfkk06mzt7e8dh">Try a demo</a>
                 <div class="lc-header-source">
                     <a class="lc-header-source-link" href="https://github.com/sdelements/lets-chat" target="_blank"><i class="fa fa-github"></i> Source Code</a>


### PR DESCRIPTION
This commit adds a "Try a demo" button to the front page, which links to:

https://demo.sandstorm.io/appdemo/qkgkaxfqhgsff8zgx2f4nf1a8xvmpte6wa19egmfkk06mzt7e8dh

This is backed by @jparyani's package of Let's Chat for Sandstorm. (Sandstorm is an open source project that makes it easy to run web applications with a click.)

More info on these app demo buttons here: https://blog.sandstorm.io/news/2015-02-06-app-demo.html

I hope you'll consider this pull request, and merge it if you like!