### PR TITLE
Add join channel on mention

### DIFF
--- a/app/controllers/rooms.js
+++ b/app/controllers/rooms.js
@@ -73,6 +73,12 @@ module.exports = function() {
             req.io.route('rooms:users');
         });
 
+    app.route('/rooms/:room/invite')
+        .all(middlewares.requireLogin, middlewares.roomRoute)
+        .post(function(req, res) {
+            req.io.route('rooms:invite');
+        });
+
 
     //
     // Sockets
@@ -237,6 +243,9 @@ module.exports = function() {
 
                 res.json(users);
             });
+        },
+        invite: function(req, res) {
+            app.io.emit('rooms:invite', req.data);
         }
     });
 };

--- a/media/js/client.js
+++ b/media/js/client.js
@@ -219,6 +219,12 @@
             room: id
         }, callback);
     };
+    Client.prototype.inviteToRoom = function(username, room) {
+        this.socket.emit('rooms:invite', {
+            room: room,
+            username: username
+        });
+    };
     //
     // Messages
     //
@@ -449,6 +455,14 @@
         });
         this.socket.on('rooms:archive', function(room) {
             that.roomArchive(room);
+        });
+        this.socket.on('rooms:invite', function (data) {
+            var currentUser = that.user.get('username');
+
+            // If invite request is for me...
+            if (data.username.endsWith(currentUser)) {
+                that.joinRoom(data.room);
+            }
         });
         this.socket.on('users:join', function(user) {
             that.addUser(user);

--- a/media/js/views/room.js
+++ b/media/js/views/room.js
@@ -21,7 +21,8 @@
             'click .submit-edit-room': 'submitEditRoom',
             'click .archive-room': 'archiveRoom',
             'click .lcb-room-poke': 'poke',
-            'click .lcb-upload-trigger': 'upload'
+            'click .lcb-upload-trigger': 'upload',
+            'inserted.atwho .lcb-entry-input': 'sendInvite'
         },
         initialize: function(options) {
             this.client = options.client;
@@ -366,6 +367,12 @@
             var $messages = this.$('.lcb-message[data-owner="' + user.id + '"]');
             $messages.find('.lcb-message-username').text('@' + user.get('username'));
             $messages.find('.lcb-message-displayname').text(user.get('displayName'));
+        },
+        sendInvite: function (e, $li) {
+            var username = $li.data('value'),
+                roomId = this.model.get('id');
+
+            this.client.inviteToRoom(username, roomId);
         }
     });
 


### PR DESCRIPTION
This is a basic implementation of #406

Currently it adds the user to the channel as soon as her username is typed into the chat box. I think it'd be nicer if she was added **after** the message that mentions her was sent, but this would require extra logic for handling adding multiple users. 

Another possible improvement would be batching invites so that typing **@@garnet @@pearl @@amethyst and @@steven** would result in a single "batch invite request" instead of four, but maybe that is just a micro-optimization.
