### PR TITLE
support mongodb file provider by MongoDB GridFS

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -66,6 +66,9 @@ var pipeline = [
             if (key === 'local') {
                 return;
             }
+            if (key === 'mongodb') {
+                return;
+            }
 
             var plugin = plugins.getPlugin(key, 'files');
 

--- a/app/core/files.js
+++ b/app/core/files.js
@@ -19,6 +19,8 @@ function FileManager(options) {
 
     if (settings.provider === 'local') {
         Provider = require('./files/local');
+    } else if (settings.provider === 'mongodb') {
+        Provider = require('./files/mongodb');
     } else {
         Provider = plugins.getPlugin(settings.provider, 'files');
     }

--- a/app/core/files/mongodb.js
+++ b/app/core/files/mongodb.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
     mongoose = require('mongoose');
 
 function mongodbParse(options) {
-    opts = options
+    var opts = options;
     if(!opts.metadata) {
         opts.metadata = {};
     }
@@ -11,7 +11,7 @@ function mongodbParse(options) {
 }
 
 function mongodbPutFile(path, name, options, fn) {
-    db = mongoose.connection.db;
+    var db = mongoose.connection.db;
     options = mongodbParse(options);
     options.metadata.filename = name;
     return new mongoose.mongo.GridStore(db, name, "w", options).open(function(err, file) {

--- a/app/core/files/mongodb.js
+++ b/app/core/files/mongodb.js
@@ -1,0 +1,54 @@
+var fs = require('fs'),
+    path = require('path'),
+    mongoose = require('mongoose');
+
+function mongodbParse(options) {
+    opts = options
+    if(!opts.metadata) {
+        opts.metadata = {};
+    }
+    return opts;
+}
+
+function mongodbPutFile(path, name, options, fn) {
+    db = mongoose.connection.db;
+    options = mongodbParse(options);
+    options.metadata.filename = name;
+    return new mongoose.mongo.GridStore(db, name, "w", options).open(function(err, file) {
+        if(err) {
+            fn(err);
+        }
+        file.writeFile(path, fn);
+    });
+}
+
+function MongoDBFiles(options) {
+    this.options = options;
+
+    this.getUrl = this.getUrl.bind(this);
+    this.save = this.save.bind(this);
+}
+
+MongoDBFiles.prototype.getUrl = function(file) {
+    return file._id;
+};
+
+MongoDBFiles.prototype.save = function(options, callback) {
+    var file = options.file,
+        doc = options.doc,
+        fileFolder = doc._id,
+        filePath = fileFolder + '/' + encodeURIComponent(doc.name);
+
+    mongodbPutFile(file.path, fileFolder, {content_type: file.mimetype}, function(err, result) {
+        if(err) {
+            callback(err);
+        }
+        // Let the clients know about the new file
+        var url = '/files/' + filePath;
+        callback(null, url, doc);
+    });
+
+    return;
+};
+
+module.exports = MongoDBFiles;


### PR DESCRIPTION
I wrote 'mongodb' file provider used MongoDB GridFS.
GridFS can save more than 16MB files.
It helps make easy to deploy Let's Chat on Heroku, I hope.