### PR TITLE
Better markup for mentions

### DIFF
--- a/media/js/util/message.js
+++ b/media/js/util/message.js
@@ -57,7 +57,7 @@ if (typeof exports !== 'undefined') {
 
     function mentions(text) {
         var mentionPattern = /\B@([\w\.]+)(?!@)\b/g;
-        return text.replace(mentionPattern, '<strong>@$1</strong>');
+        return text.replace(mentionPattern, '<span class="lcb-message-mention">@$1</span>');
     }
 
     function roomLinks(text, data) {

--- a/media/less/style/chat/messages.less
+++ b/media/less/style/chat/messages.less
@@ -113,6 +113,10 @@
     }
 }
 
+.lcb-message-mention {
+    font-weight: bold;
+}
+
 // Eugh Firefox
 @-moz-document url-prefix() {
     .lcb-message-text {


### PR DESCRIPTION
I created this branch mainly to test that my dev environment for Let's Chat is set up correctly but I think it's still useful.

### What?
In current `master`, mentions in messages are just transformed into something like `<strong>@dfyx</strong>`. My branch changes this to generate `<span class="lcb-message-mention">@dfyx</span>`. The CSS to make it look the same as before is included.

### Why?
As said, it was initially more of an experiment. But in general I think it makes it easier to add styles and maybe scripts (like a tooltip) to mentions.