### PR TITLE
Require closing colon for emotes

### DIFF
--- a/media/js/util/message.js
+++ b/media/js/util/message.js
@@ -106,7 +106,7 @@ if (typeof exports !== 'undefined') {
     }
 
     function emotes(text, data) {
-        var regex = new RegExp('\\B(:[a-z0-9_\\+\\-]+:?)[\\b]?', 'ig');
+        var regex = new RegExp('\\B(:[a-z0-9_\\+\\-]+:)[\\b]?', 'ig');
 
         return text.replace(regex, function(group) {
             var key = group.split(':')[1];


### PR DESCRIPTION
This causes lots of irritation especially when pasting Ruby snippets. Ruby symbols are replaced by an emote too often. Is there a particular reason for not doing this?