### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+bower_components
+node_modules


### PR DESCRIPTION
This reduces the amount of data that needs to be transferred to the Docker daemon. Especially the `.git` folder is pretty large. `node_modules` and `bower_components` could cause non deterministic builds, therefore they should be ignored as well.