### PR TITLE
Drop root privileges in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,11 @@ FROM node:0.10-onbuild
 MAINTAINER SD Elements
 
 ENV LCB_DATABASE_URI mongodb://db/letschat
+
+RUN	groupadd -r node \
+&&	useradd -r -g node node \
+&&	chown node:node uploads
+
+USER node
+
 EXPOSE 5000


### PR DESCRIPTION
Even though running root inside a container is more secure than running root outside a container it is not necessary. Lets-Chat works just fine with a user that has got reduced privileges. I am running this `Dockerfile` in production.