### PR TITLE
Fix broken legacy passwords

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -209,7 +209,7 @@ UserSchema.methods.comparePassword = function(password, cb) {
 
     // Legacy password hashes
     if (salt && (hash.sha256(password, salt) === this.password)) {
-        return cb(null, true)
+        return cb(null, true);
     }
 
     // Current password hashes
@@ -225,7 +225,7 @@ UserSchema.methods.comparePassword = function(password, cb) {
 
         cb(null, false);
 
-    }.bind(this));
+    });
 
 };
 

--- a/defaults.yml
+++ b/defaults.yml
@@ -56,6 +56,5 @@ auth:
   local:
     enableRegistration: true
     passwordRegex: ^.{8,64}$
-    salt: secretsauce # Required when upgrading from version < 0.3
 
 noRobots: true # Serve robots.txt with disallow

--- a/settings.yml.sample
+++ b/settings.yml.sample
@@ -38,4 +38,3 @@ auth:
   providers: [local]
   local:
     enableRegistration: true
-    salt: secretsauce # Required when upgrading from version < 0.3


### PR DESCRIPTION
The bcrypt module gives an error if it encounters a legacy password hash.

I just took out those checks and placed them before bcrypt happens.