### PR TITLE
Enable XMPP in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,4 @@ RUN	groupadd -r node \
 USER node
 
 EXPOSE 5000
+EXPOSE 5222

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ app:
     - LCB_DATABASE_URI=mongodb://db/letschat
   ports:
     - 5000:5000
+    - 5222:5222
+  environment:
+    - LCB_XMPP_ENABLE=true
+    - LCB_XMPP_PORT=5222
 
 # Mongo Database
 db:


### PR DESCRIPTION
This is a better version of my broken pull request (this time coming from a feature branch, to avoid breakage).

The intention here is to enable port 5222 for XMPP within the container, as well as expose that port. By default, this is then forwarded outbound by docker-compose. Additionally, the environmental variables to enable XMPP and set the port are passed into the container, so XMPP should work "out of the box".