### PR TITLE
Scroll down after own message

### DIFF
--- a/media/js/views/room.js
+++ b/media/js/views/room.js
@@ -267,6 +267,8 @@
                 text: $textarea.val()
             });
             $textarea.val('');
+            this.scrollLocked = true;
+            this.scrollMessages();
         },
         addMessage: function(message) {
             // Smells like pasta


### PR DESCRIPTION
When you scroll up to see older messages and then reply to one of them, you probably want to see the message you just typed instead of getting no response whatsoever. At least I do. :)