### PR TITLE
Handling error on Avatar caching. Ignoring Exception

### DIFF
--- a/app/core/avatar-cache.js
+++ b/app/core/avatar-cache.js
@@ -40,8 +40,7 @@ AvatarCache.prototype.add = function(user) {
 
             this.core.emit('avatar-cache:update', user);
         }.bind(this));
-    }.bind(this)).on('error', function(e){
-    });
+    }.bind(this)).on('error', function(){ });
 };
 
 module.exports = AvatarCache;

--- a/app/core/avatar-cache.js
+++ b/app/core/avatar-cache.js
@@ -40,7 +40,8 @@ AvatarCache.prototype.add = function(user) {
 
             this.core.emit('avatar-cache:update', user);
         }.bind(this));
-    }.bind(this));
+    }.bind(this)).on('error', function(e){
+    });
 };
 
 module.exports = AvatarCache;


### PR DESCRIPTION
I'm trying to run Lets chat inside corporate network behind proxy.
Application crashes when Avatar caching is called. Problem is that there is no error handler for HTTP request. The error handler ignores the error as the calls to cache handle the situation where Cache does not contain user Avatar.

Ideally, it should be possible to setup HTTP Proxy for the HTTP calls to the external services. This pull request only fixes the very immediate problem of Crashing Application.

There should be a way to use http.get function with proxy.