### PR TITLE
Add note that Kerberos plugin requires 0.10.x

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,7 +4,7 @@ We'll be improving this document soon.
 
 #### What version of Node.JS is required?
 
-Let's Chat requires Node.JS version ```0.10.x``` or ```0.12.x```. You will have a bad time if you try to use a different version.
+Let's Chat requires Node.JS version ```0.10.x``` or ```0.12.x```. You will have a bad time if you try to use a different version. Note that the Kerberos plugin currently requires ```0.10.x``` and will not work with ```0.12.x```.
 
 #### Do I need MongoDB running?
 


### PR DESCRIPTION
Until the Kerberos plugin can be fixed to work on 0.12.x (see https://github.com/sdelements/lets-chat-kerberos/issues/1 ) , users considering this feature should be directed to using 0.10.x where possible as downgrading is difficult.