### PR TITLE
Implement chat input field history.

### DIFF
--- a/media/js/views/room.js
+++ b/media/js/views/room.js
@@ -375,7 +375,20 @@
             this.scrollLocked = true;
             this.scrollMessages();
         },
+        getCaretPosition: function(e, field) {
+            var caretPosition = 0;
+            if (document.selection) {
+                field.focus ();
+                var oSel = document.selection.createRange ();
+                oSel.moveStart ('character', -field.value.length);
+                caretPosition = oSel.text.length;
+            } else if (field.selectionStart || field.selectionStart == '0') {
+                caretPosition = field.selectionStart;
+            }
+            return (caretPosition);
+        },
         historyUp: function(e) {
+            var caretPosition = getCaretPosition();
             if (e.type === 'keyup' && e.keyCode === 38 && this.model.get('messageHistoryCurrent') > 0) {
                 e.preventDefault();
                 this.model.set({
@@ -383,8 +396,11 @@
                 });
                 this.model.get('setHistory')();
             }
+            console.log('event', e);
+            e.setSelectionRange(caretPosition, caretPosition);
         },
         historyDown: function(e) {
+            var caretPosition = getCaretPosition();
             if (e.type === 'keydown' && e.keyCode === 40) {
                 e.preventDefault();
                 if (this.model.get('messageHistoryCurrent') < this.model.get('messageHistory').length - 1) {
@@ -396,6 +412,8 @@
                     this.model.get('setHistory')();
                 }
             }
+            console.log('event', e);
+            e.setSelectionRange(caretPosition, caretPosition);
         },
         addMessage: function(message) {
             // Smells like pasta

--- a/media/js/views/room.js
+++ b/media/js/views/room.js
@@ -13,6 +13,8 @@
         events: {
             'scroll .lcb-messages': 'updateScrollLock',
             'keypress .lcb-entry-input': 'sendMessage',
+            'keyup .lcb-entry-input': 'historyUp',
+            'keydown .lcb-entry-input': 'historyDown',
             'click .lcb-entry-button': 'sendMessage',
             'DOMCharacterDataModified .lcb-room-heading, .lcb-room-description': 'sendMeta',
             'click .lcb-room-toggle-sidebar': 'toggleSidebar',
@@ -31,6 +33,15 @@
 
             this.model.set('iAmOwner', iAmOwner);
             this.model.set('iCanEdit', iCanEdit);
+            this.model.set('messageHistory', new Array());
+            this.model.set('messageHistoryCurrent', -1);
+            var setHistory = function() {
+                var messages = this.model.get('messageHistory');
+                var lastMessage = messages[this.model.get('messageHistoryCurrent')];
+                var $textarea = this.$('.lcb-entry-input');
+                $textarea.val(lastMessage);
+            };
+            this.model.set('setHistory', setHistory.bind(this));
 
             this.template = options.template;
             this.messageTemplate =
@@ -353,9 +364,38 @@
                 room: this.model.id,
                 text: $textarea.val()
             });
+            var messageHistory = this.model.get('messageHistory').concat($textarea.val());
+            this.model.set({
+                'messageHistory': messageHistory
+            });
+            this.model.set({
+                'messageHistoryCurrent': messageHistory.length
+            });
             $textarea.val('');
             this.scrollLocked = true;
             this.scrollMessages();
+        },
+        historyUp: function(e) {
+            if (e.type === 'keyup' && e.keyCode === 38 && this.model.get('messageHistoryCurrent') > 0) {
+                e.preventDefault();
+                this.model.set({
+                    'messageHistoryCurrent': this.model.get('messageHistoryCurrent') - 1
+                });
+                this.model.get('setHistory')();
+            }
+        },
+        historyDown: function(e) {
+            if (e.type === 'keydown' && e.keyCode === 40) {
+                e.preventDefault();
+                if (this.model.get('messageHistoryCurrent') < this.model.get('messageHistory').length - 1) {
+                    this.model.set({
+                        'messageHistoryCurrent': this.model.get('messageHistoryCurrent') + 1
+                    });
+                }
+                if(this.model.get('messageHistoryCurrent') < this.model.get('messageHistory').length) {
+                    this.model.get('setHistory')();
+                }
+            }
         },
         addMessage: function(message) {
             // Smells like pasta


### PR DESCRIPTION
This pull Request implements a history for the chat input field. One can get the old chat messages by pressing the arrow-key-up and arrow-key-down buttons.

Fixes #550. 

PS: Newer worked with backbone before. I am happy about code suggestions and improvements and look forward to work more on this project :smile: 