### PR TITLE
Add stop command in package.json for npm stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
+    "stop": "pkill --signal SIGINT letschat",  
     "prestart": "migroose",
     "migrate": "migroose",
     "test": "eslint ."


### PR DESCRIPTION
It's easier to use "npm stop" command to stop Let's Chat, especially when you want to make it a service for your server.