### PR TITLE
Fix changing the browser title

### DIFF
--- a/media/js/views/window.js
+++ b/media/js/views/window.js
@@ -30,7 +30,7 @@
 
             this.client = options.client;
             this.rooms = options.rooms;
-            this.originalTitle = this.$('title').text();
+            this.originalTitle = document.title;
             this.title = this.originalTitle;
 
             $(window).on('focus blur', _.bind(this.onFocusBlur, this));
@@ -92,7 +92,7 @@
                 }
                 titlePrefix += ') ';
             }
-            this.$('title').html(titlePrefix + this.title);
+            document.title = titlePrefix + this.title;
         },
         flashFaviconBadge: function() {
             if (!this.faviconBadgeTimer) {
@@ -116,11 +116,11 @@
             }
             if (name) {
                 this.title = $('<pre />').text(name).html() +
-                ' &middot; ' + this.originalTitle;
+                ' \u00B7 ' + this.originalTitle;
             } else {
                 this.title = this.originalTitle;
             }
-            this.$('title').html(this.title);
+            document.title = this.title;
         }
     });
 


### PR DESCRIPTION
It now uses the `document.title` property to change the title. My users reported that the title stopped updating as of the last update of Google Chrome. Using `document.title` is the canonical way and seems to fix their issue.