### PR TITLE
History

### DIFF
--- a/media/js/views/room.js
+++ b/media/js/views/room.js
@@ -22,7 +22,10 @@
             'click .archive-room': 'archiveRoom',
             'click .lcb-room-poke': 'poke',
             'click .lcb-upload-trigger': 'upload',
-            'keyup .lcb-entry-input': 'messageUp'
+            'keyup .lcb-entry-input': function(e) {
+                this.messageUp(e);
+                this.messageDown(e);
+            }
         },
         initialize: function(options) {
             this.client = options.client;
@@ -353,6 +356,20 @@
                 var historyCurrent = this.model.get('historyCurrent');
                 historyCurrent++;
                 if (historyCurrent < history.length) {
+                    var currentMessage = this.model.get('history')[historyCurrent]
+                    $textarea.val(currentMessage.text);
+                    this.model.set('historyCurrent', historyCurrent)
+                }
+            }
+        },
+        messageDown: function(e) {
+            if (e.type === 'keyup' && e.keyCode === 40) {
+                e.preventDefault()
+                var $textarea = this.$('.lcb-entry-input');
+                var history = this.model.get('history');
+                var historyCurrent = this.model.get('historyCurrent');
+                historyCurrent--;
+                if (0 <= historyCurrent) {
                     var currentMessage = this.model.get('history')[historyCurrent]
                     $textarea.val(currentMessage.text);
                     this.model.set('historyCurrent', historyCurrent)

--- a/media/js/views/room.js
+++ b/media/js/views/room.js
@@ -356,9 +356,10 @@
                 var historyCurrent = this.model.get('historyCurrent');
                 historyCurrent++;
                 if (historyCurrent < history.length) {
-                    var currentMessage = this.model.get('history')[historyCurrent]
-                    $textarea.val(currentMessage.text);
-                    this.model.set('historyCurrent', historyCurrent)
+                    var currentMessage = this.model.get('history')[historyCurrent];
+                    $textarea.val(currentMessage.message.text);
+                    this.setCaretPosition($textarea, currentMessage.selection);
+                    this.model.set('historyCurrent', historyCurrent);
                 }
             }
         },
@@ -370,11 +371,24 @@
                 var historyCurrent = this.model.get('historyCurrent');
                 historyCurrent--;
                 if (0 <= historyCurrent) {
-                    var currentMessage = this.model.get('history')[historyCurrent]
-                    $textarea.val(currentMessage.text);
-                    this.model.set('historyCurrent', historyCurrent)
+                    var currentMessage = this.model.get('history')[historyCurrent];
+                    $textarea.val(currentMessage.message.text);
+                    this.setCaretPosition($textarea, currentMessage.selection);
+                    this.model.set('historyCurrent', historyCurrent);
                 }
             }
+        },
+        getCaretPosition: function(field) {
+            var rawfield = field[0];
+            return {
+                start: rawfield.selectionStart,
+                end: rawfield.selectionEnd
+            };
+        },
+        setCaretPosition: function(field, selection) {
+            var rawfield = field[0];
+            rawfield.focus();
+            rawfield.setSelectionRange(selection.start, selection.end);
         },
         sendMessage: function(e) {
             if (e.type === 'keypress' && e.keyCode !== 13 || e.altKey) return;
@@ -390,7 +404,10 @@
             this.client.events.trigger('messages:send', message);
 
             var history = _.clone(this.model.get('history'));
-            history.unshift(message);
+            history.unshift({
+                message: message,
+                selection: this.getCaretPosition($textarea)
+            });
             this.model.set('history', history);
             this.model.set('historyCurrent', -1);
 


### PR DESCRIPTION
Closed #555 - I reimplemented this, sorry for the inconvenience.

This pull Request implements a history for the chat input field. One can get the old chat messages by pressing the arrow-key-up and arrow-key-down buttons.

The cursor selections are stored in the history. 

Fixes #550.
