### PR TITLE
Naive domain whitelist implementation

### DIFF
--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -225,7 +225,9 @@ module.exports = function() {
                 return str.indexOf(suffix, str.length - suffix.length) !== -1;
             };
 
-            if (!_.some(settings.domains, function (domain) {
+            var domains = settings.domains || [];
+
+            if (domains.length > 0 && !_.some(settings.domains, function(domain) {
                 return endsWith(fields.email, domain);
             })) {
                 var message = 'Sorry, your email is not from a whitelisted domain.';

--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -221,6 +221,20 @@ module.exports = function() {
 
             var fields = req.body || req.data;
 
+            var endsWith = function(str, suffix) {
+                return str.indexOf(suffix, str.length - suffix.length) !== -1;
+            };
+
+            if (!_.some(settings.domains, function (domain) {
+                return endsWith(fields.email, domain);
+            })) {
+                var message = 'Sorry, your email is not from a whitelisted domain.';
+                return res.status(400).json({
+                    status: 'error',
+                    message: message
+                });
+            }
+
             // Sanity check the password
             var passwordConfirm = fields.passwordConfirm || fields.passwordconfirm || fields['password-confirm'];
 


### PR DESCRIPTION
RE: #218 on the subject of registration requirements, this introduces a function which will iterate over a simple collection in the yaml settings file looking like the following:

```
domains:
  - 'echo.co'
  - 'blackwood.io'
```

Which will immediately kill registration if the email doesn't end with one of these particular strings.

Without listing the whitelisted domains, this is a pretty good barrier against someone creating a mock account from one of your domains (e.g. "fakejerk@blackwood.io"), but still thats a possibility, so I think this goes hand in hand with the other feature request, namely email verification.

Still, this might be a little step forward. I haven't yet tested how the `_.some` function reacts to an empty array/collection, so we might need to add one more check for a count over 0 before the whitelist check even runs.