### PR TITLE
Add cloudron letschat app to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For installation instructions, please use the following links:
 * [Docker][install-docker]
 * [Heroku][install-heroku]
 * [Vagrant][install-vagrant]
+* [Cloudron][install-cloudron]
 
 ## Support & Problems
 
@@ -90,3 +91,4 @@ Released under [the MIT license][license].
 [install-docker]: https://registry.hub.docker.com/u/sdelements/lets-chat/
 [install-heroku]: https://github.com/sdelements/lets-chat/wiki/Heroku
 [install-vagrant]: https://github.com/sdelements/lets-chat/wiki/Vagrant
+[install-cloudron]: https://github.com/sdelements/lets-chat/wiki/Cloudron


### PR DESCRIPTION
Hey,
Thanks for this awesome chat app.

This PR adds Cloudron as a deployment option for Let's Chat. It relies on wiki changes (not sure how to make a PR for that). https://github.com/cloudron-io/lets-chat/wiki/Cloudron is the text for the Cloudron page. 

It will be great if you can have us listed!

The source code of the app is at https://github.com/cloudron-io/letschat-app.