### PR TITLE
Popup Preview for pasted Images

### DIFF
--- a/media/js/chat.js
+++ b/media/js/chat.js
@@ -10,10 +10,17 @@
 //= require views/client.js
 //= require client.js
 
-$(function() {
+$(function () {
     window.client = new window.LCB.Client({
         filesEnabled: $('#lcb-upload').length > 0,
         giphyEnabled: $('#lcb-giphy').length > 0
     });
     window.client.start();
+
+    $('#myModal').on('show.bs.modal', function (e) {
+        var img = $(e.relatedTarget).attr('src'); //image
+        $('#showimg').attr('src', img);
+        $('#showimg').parent().attr("href", img);
+        $('.modal-dialog').width("95vw");
+    });
 });

--- a/media/js/chat.js
+++ b/media/js/chat.js
@@ -10,7 +10,7 @@
 //= require views/client.js
 //= require client.js
 
-$(function () {
+$(function() {
     window.client = new window.LCB.Client({
         filesEnabled: $('#lcb-upload').length > 0,
         giphyEnabled: $('#lcb-giphy').length > 0

--- a/media/js/util/message.js
+++ b/media/js/util/message.js
@@ -87,11 +87,10 @@ if (typeof exports !== 'undefined') {
 
     function links(text) {
         if (imagePattern.test(text)) {
-            return text.replace(imagePattern, function(url) {
+            return text.replace(imagePattern, function (url) {
                 var uri = encodeEntities(_.unescape(url));
-                return '<a class="thumbnail" href="' + uri +
-                       '" target="_blank"><img src="' + uri +
-                       '" alt="Pasted Image" /></a>';
+                return '<a class="thumbnail" ><img src="' + uri +
+                       '" alt="Pasted Image" data-target="#myModal" data-toggle="modal"/></a>';
             });
         } else {
             return text.replace(linkPattern, function(url) {

--- a/media/js/util/message.js
+++ b/media/js/util/message.js
@@ -87,7 +87,7 @@ if (typeof exports !== 'undefined') {
 
     function links(text) {
         if (imagePattern.test(text)) {
-            return text.replace(imagePattern, function (url) {
+            return text.replace(imagePattern, function(url) {
                 var uri = encodeEntities(_.unescape(url));
                 return '<a class="thumbnail" ><img src="' + uri +
                        '" alt="Pasted Image" data-target="#myModal" data-toggle="modal"/></a>';

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -18,6 +18,7 @@
 <% endblock %>
 
 <% block body %>
+    <div class="modal fade" id="myModal" role="dialog"> <div class="modal-dialog"> <!-- Modal content--> <div class="modal-content"> <div class="modal-body"> <button type="button" class="close pull-left" data-dismiss="modal">&times;</button><a href="" target="_blank"> <img style="margin-right:auto;margin-left:auto;" class="img-responsive" src="" alt="" id="showimg"> </a></div> </div> </div> </div>
     <div id="lcb-client" class="lcb-client">
         <div class="lcb-header">
             <button type="button" class="btn lcb-header-toggle">
@@ -50,11 +51,11 @@
                         </a>
                     </li>
                     <% if settings.xmpp.enable %>
-                        <li>
-                            <a data-toggle="modal" href="#lcb-xmpp">
-                                <i class="fa fa-fw fa-comments"></i> <$ __('XMPP/Jabber') $>
-                            </a>
-                        </li>
+                    <li>
+                        <a data-toggle="modal" href="#lcb-xmpp">
+                            <i class="fa fa-fw fa-comments"></i> <$ __('XMPP/Jabber') $>
+                        </a>
+                    </li>
                     <% endif %>
                     <li>
                         <a data-toggle="modal" href="#lcb-tokens">
@@ -112,7 +113,7 @@
                         <$ __('All Rooms') $>
                     </h2>
 
-                    
+
                 </header>
                 <ul class="lcb-rooms-list"></ul>
                 <% include 'includes/modals/add-room.html' %>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -51,11 +51,11 @@
                         </a>
                     </li>
                     <% if settings.xmpp.enable %>
-                    <li>
-                        <a data-toggle="modal" href="#lcb-xmpp">
-                            <i class="fa fa-fw fa-comments"></i> <$ __('XMPP/Jabber') $>
-                        </a>
-                    </li>
+                        <li>
+                            <a data-toggle="modal" href="#lcb-xmpp">
+                                <i class="fa fa-fw fa-comments"></i> <$ __('XMPP/Jabber') $>
+                            </a>
+                        </li>
                     <% endif %>
                     <li>
                         <a data-toggle="modal" href="#lcb-tokens">
@@ -113,7 +113,7 @@
                         <$ __('All Rooms') $>
                     </h2>
 
-
+                    
                 </header>
                 <ul class="lcb-rooms-list"></ul>
                 <% include 'includes/modals/add-room.html' %>


### PR DESCRIPTION
I used the embedded jQuery und Bootstrap to open a Modal containing pasted Images. 
The current solution to give only a download link was for my usecase insufficient.
I apologize the style attributes, i did not found a Site.css...

This is a screenshot of the top where the modal appears, it scales in width to 95vw and can be scrolled down till the end.
![unbekannt](https://cloud.githubusercontent.com/assets/4329883/17913679/23c95cc8-699c-11e6-9233-02e5a2cf6ec7.jpg)
