### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/app/core/presence/connection.js
+++ b/app/core/presence/connection.js
@@ -2,7 +2,7 @@
 
 var EventEmitter = require('events').EventEmitter,
     util = require('util'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 
 function Connection(type, user) {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "mongoose-unique-validator": "^1.0.2",
     "mongoose-validate": "0.0.5",
     "multer": "^1.1.0",
-    "node-uuid": "^1.4.7",
     "node-xmpp-server": "^2.2.0",
     "node_hash": "^0.2.0",
     "nunjucks": "^2.4.2",
@@ -91,7 +90,8 @@
     "passport-local": "1.0.0",
     "passport.socketio": "3.6.2",
     "require-directory": "~2.1.1",
-    "require-tree": "^1.1.1"
+    "require-tree": "^1.1.1",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^3.1.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.