### PR TITLE
Cluster regime

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,48 @@
 
 'use strict';
 
+var servers_count;
+var bCluster = 1;
+
+var settings = require('./app/config');
+
+if(settings.cluster_regime !== undefined) {
+  servers_count = settings.cluster_regime.servers_count;
+}
+
+if(servers_count === undefined || servers_count === null || servers_count === 0) {
+  bCluster = 0;
+  servers_count = 1;
+}
+
+function startCluster(servers_count) {
+  const cluster = require('cluster');
+  if (cluster.isMaster) {
+    if(servers_count == -1) {
+      servers_count = require('os').cpus().length;
+    }
+
+    console.log('Setting up cluster with 1 Master and ' + servers_count + ' workers..');
+
+    for (var i=0; i < servers_count; i++) {
+      cluster.fork();
+    }
+
+    cluster.on('online', function(worker) {
+      console.log('Worker:' + worker.process.pid + ' is online');
+    });
+
+    cluster.on('exit', function(worker, code, signal) {
+      console.log('Worker:' + worker.process.pid + ' exited');
+      cluster.fork(); /* Restart a new worker */
+    });
+  } else {
+    startSingleNodeInstance();
+  }
+}  
+
+function startSingleNodeInstance() {
+
 process.title = 'letschat';
 
 require('colors');
@@ -23,7 +65,6 @@ var _ = require('lodash'),
     connectMongo = require('connect-mongo/es5'),
     all = require('require-tree'),
     psjon = require('./package.json'),
-    settings = require('./app/config'),
     auth = require('./app/auth/index'),
     core = require('./app/core/index');
 
@@ -69,6 +110,41 @@ var session = {
     resave: false,
     saveUninitialized: true
 };
+
+app.get('/myroom', function(req, res) {
+  var  Room = require('./app/models/room');
+  Room.find({}, function( err, data) {
+    if(err) {
+      console.log(err);
+      res.json({'status': 'Could not delete all messages. Do it manually'});
+      return;
+    }
+      res.json({'rooms': data});
+      return;
+  });
+});
+
+//Delete
+app.get('/deleteall', function(req, res) {
+  console.log('Deleting stale data from last run');
+  var  Message = require('./app/models/message');
+  var  Room = require('./app/models/room');
+  Message.remove({}, function(err) {
+    if (err) {
+	  res.json({'status': 'Could not delete all messages. Do it manually'});
+	  return;
+	}
+    Room.remove({}, function(err) {
+      if (err) {
+	    res.json({'status': 'Could not delete all the rooms. Do it manually'});
+	    return;
+	  }
+    });
+
+    res.status(200);
+	res.json({'status': 'all clear'});
+  });
+});
 
 // Set compression before any routes
 app.use(compression({ threshold: 512 }));
@@ -117,6 +193,25 @@ app.use(require('connect-assets')({
 app.use('/media', express.static(__dirname + '/media', {
     maxAge: '364d'
 }));
+
+// Stop
+app.get('/stopserver', function(req, res) {
+  console.log('Got the SIGINT signal. Dumping memory usage stat.');
+  var after_memusage = process.memoryUsage();
+  setTimeout(print_stats, 250);
+  function print_stats() {
+    console.log('Memory usage is: ');
+    ['rss', 'heapTotal', 'heapUsed'].forEach(function(key) {
+      var a = after_memusage[key] / (1024 * 1024);
+    console.log('%sM %s', a.toFixed(2), key);
+  });
+  
+  console.log('Exiting ...');
+  res.json({message: 'Server stopped'});
+    server.close();
+    process.exit(0);
+ }
+});
 
 // Templates
 var nun = nunjucks.configure('templates', {
@@ -268,3 +363,13 @@ mongoose.connect(settings.database.uri, function(err) {
     checkForMongoTextSearch();
     startApp();
 });
+
+}
+
+if(bCluster === 1) {
+  startCluster(servers_count); 
+} else {
+  console.log('Starting a single instance of Node.js process with (pid: ' + process.pid + ')');
+  startSingleNodeInstance();
+}
+

--- a/defaults.yml
+++ b/defaults.yml
@@ -75,3 +75,10 @@ rooms:
 
 i18n:
   locale: en
+
+# -1 means using one server for all the processors available
+# undefined, absent, or 0 specification means monolithic regime
+# otherwise servers_count is self commenting
+cluster_regime:
+  servers_count: 0 
+

--- a/defaults.yml
+++ b/defaults.yml
@@ -76,9 +76,9 @@ rooms:
 i18n:
   locale: en
 
-# -1 means using one server for every processors available
+# -1 means using one server for every processor available
 # undefined, absent, or 0 specification means monolithic regime
 # otherwise servers_count is self commenting
 cluster_regime:
-  servers_count: 0 
+  servers_count: 0
 

--- a/defaults.yml
+++ b/defaults.yml
@@ -76,7 +76,7 @@ rooms:
 i18n:
   locale: en
 
-# -1 means using one server for all the processors available
+# -1 means using one server for every processors available
 # undefined, absent, or 0 specification means monolithic regime
 # otherwise servers_count is self commenting
 cluster_regime:

--- a/settings.yml.sample
+++ b/settings.yml.sample
@@ -34,7 +34,7 @@ database:
 secrets:
   cookie: secretsauce
 
-# -1 means using one server for all the processors available
+# -1 means using one server for every processors available
 # undefined, absent, or 0 specification means monolithic regime
 # otherwise servers_count is self commenting
 cluster_regime:

--- a/settings.yml.sample
+++ b/settings.yml.sample
@@ -34,6 +34,12 @@ database:
 secrets:
   cookie: secretsauce
 
+# -1 means using one server for all the processors available
+# undefined, absent, or 0 specification means monolithic regime
+# otherwise servers_count is self commenting
+cluster_regime:
+  servers_count: 0 
+
 auth:
   providers: [local]
   local:

--- a/settings.yml.sample
+++ b/settings.yml.sample
@@ -34,7 +34,7 @@ database:
 secrets:
   cookie: secretsauce
 
-# -1 means using one server for every processors available
+# -1 means using one server for every processor available
 # undefined, absent, or 0 specification means monolithic regime
 # otherwise servers_count is self commenting
 cluster_regime:


### PR DESCRIPTION
Dear Reviewer

We propose adding a cluster regime of operation to Let's Chat. The cluster regime aims using the entire capacity of the processors available. In this context, we mention that we benchmark-ed the application using requests per second as an indicator of throughput. We report throughput for Let's Chat in monolithic and cluster regimes in the following.

**baseline monolithic**
requests per second = 14.07143547818

**monolithic**
servers_count=0
requests per second = 14.0404924496

**cluster_regime**

servers_count=1
requests per second = 13.9350569156

servers_count=2
requests per second = 13.737977303

servers_count = 3
requests per second = 20.211262196

servers_count=4
requests per second = 25.894939939

servers_count=5
requests per second = 29.607414638

servers_count=6
requests per second = 33.669860264

servers_counter=7
requests per second = 36.365360776

servers_count=8
requests per second = 39.596573071

This analysis represents an empirical proof of linearity gain when cluster mode is used. 

We proposed to put the specification of monolithic versus cluster regime in file defaults.yml.
The parameter cluster_regime.servers_count is the one that define regime. We illustrate here the
specific modification.

\# -1 means using one server for every processor available
\# undefined, absent, or 0 specification means monolithic regime
\# otherwise servers_count is self commenting
cluster_regime:
  servers_count: 0

In this context, we would like to insert this into documentation. Could you please help and indicate how to modify the wiki or what is a correct place to put it?

We also mention we used an Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz processor.

Could you please consider our modification? We are looking forward to hearing from you. 

Best regards,
  Uttam Pawar and Octavian Soldea