### PR TITLE
use shorthand name for box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,8 +27,7 @@ EOF
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise32"
-  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.box = "ubuntu/precise32"
 
   config.vm.define :lcb do |lcb|
       lcb.vm.network "forwarded_port", guest: 5000, host: 5000


### PR DESCRIPTION
files.vagrantup.com redirects to hashicorp-files.hashicorp.com which is [no longer active](https://github.com/hashicorp/vagrant/issues/9847). 

The preferred way to access boxes is to refer to them with their [shorthand name](https://www.vagrantup.com/docs/boxes.html).